### PR TITLE
fix: selected index set to currently focused pane

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -119,8 +119,17 @@ impl State {
             tab_info,
         });
 
-        // Set default location of selected idx to the center
-        self.selected = self.panes.len() / 2;
+        // Set default location of selected idx to currently focused pane
+        if let Some(focused_pane) = &self.focused_pane {
+            for (idx,pane) in self.panes.iter().enumerate() {
+                if pane.pane_info.id == focused_pane.pane_info.id {
+                    self.selected = idx;
+                }
+            }
+        }else{
+            self.selected = 0;
+        }
+
         Some(())
     }
 }


### PR DESCRIPTION
It's really annoying every time harpoon pane opens and the cursor is not in current pane and  end up switching to  the same pane. When switching frequently between fewer panes , its nice to know i wont end up on the same pane.