### PR TITLE
feature: add capital A to add all current panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Copy of the original [harpoon](https://github.com/ThePrimeagen/harpoon) for nvim
 ## Usage
 
 - `a` to add pane to list
+- `A` to add all current panes to list
 - `Up` and `Down` or `j` and `k` to cycle through pane list
 - `d` to remove pane from list
 - `Enter` or `l` to switch to the selected pane

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,28 @@ impl ZellijPlugin for State {
                 self.update_panes();
                 should_render = true;
             }
+            Event::Key(Key::Char('A')) => {
+                let current_pane_ids: Vec<u32> = self.panes.iter().map(|p| p.pane_info.id).collect();
+                if let Some(pane_manifest) = &self.pane_manifest {
+                    if let Some(tab_info) = &self.tab_info {
+                        for (tab_position, panes) in &pane_manifest.panes {
+                            if let Some(tab) = tab_info.iter().find(|t| t.position == *tab_position) {
+                                for pane in panes {
+                                    if !pane.is_plugin && !current_pane_ids.contains(&pane.id) {
+                                        self.panes.push(Pane {
+                                            pane_info: pane.clone(),
+                                            tab_info: tab.clone(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                self.sort_panes();
+                should_render = true;
+                hide_self();
+            },
             Event::Key(Key::Char('a')) => {
                 let panes_ids: Vec<u32> = self.panes.iter().map(|p| p.pane_info.id).collect();
                 if let Some(pane) = &self.focused_pane {


### PR DESCRIPTION
The purpose of the feature is to add all current panes to the list.

By having many panes opened before using the plugin, you have to manually switch to each tab and add it one by one.
It's a little bit painfull, especially by launching zellij with layouts that have many panes at the beginning.
So with `A` you can add them all at once.