### PR TITLE
Add keybinding hints line in bottom of harpoon's pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,15 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,9 +852,6 @@ dependencies = [
 name = "harpoon"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
- "chrono",
- "owo-colors",
  "serde",
  "serde_json",
  "zellij-tile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,6 @@ edition = "2021"
 authors = ["Ignacio Aleman <onsen@duck.com>"]
 
 [dependencies]
-ansi_term = "0.12.1"
-chrono = "0.4.26"
-owo-colors = "3.5.0"
 serde = "1.0.175"
 serde_json = "1.0.103"
 zellij-tile = "0.42.2"


### PR DESCRIPTION
Hey,

I don't know if you find this useful but I made a small addition to include the keybindings at the bottom of harpoon's pane to show the keybinding's available. I tried to keep the way those are shown similar to how it's usually in zellij. 

Maybe I shouldn't have included this but I also updated how the pinned panes are listed to use available UI elements from zellij's API and it should match the selected theme. This way we also show the tab where the pinned pane is in. 

If anything is not up to convention or you think it should not be in a certain way, I'm open to making changes.