### PR TITLE
Add per-session persistence for pinned panes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,12 @@ use zellij_tile::prelude::*;
 ///
 /// Docs: https://docs.rs/zellij-tile/latest/zellij_tile/prelude/struct.PaneInfo.html
 #[derive(Clone, Serialize, Deserialize)]
+struct PaneBookmark {
+    tab_name: String,
+    pane_title: String,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Pane {
     pub pane_info: PaneInfo,
     pub tab_info: TabInfo,
@@ -101,6 +107,8 @@ struct State {
     focused_pane: Option<Pane>,
     tab_info: Option<Vec<TabInfo>>,
     pane_manifest: Option<PaneManifest>,
+    session_name: Option<String>,
+    pending_bookmarks: Vec<PaneBookmark>,
 }
 
 impl State {
@@ -143,6 +151,9 @@ impl State {
         // Drop any panes that no longer exist and refresh tab info for moved ones
         self.panes = get_valid_panes(&self.panes.clone(), &pane_manifest, &tab_info);
 
+        // Match pending bookmarks to live panes (restores panes after session reload)
+        self.match_pending_bookmarks(&pane_manifest, &tab_info);
+
         // Track which pane the user was in before harpoon opened
         let focused_tab = get_focused_tab(&tab_info)?;
         let focused_pane_info = get_focused_pane(focused_tab.position, &pane_manifest)?;
@@ -161,6 +172,101 @@ impl State {
 
         Some(())
     }
+
+    fn match_pending_bookmarks(&mut self, pane_manifest: &PaneManifest, tab_infos: &[TabInfo]) {
+        if self.pending_bookmarks.is_empty() {
+            return;
+        }
+
+        let current_pane_ids: Vec<u32> = self.panes.iter().map(|p| p.pane_info.id).collect();
+        let mut matched_indices = Vec::new();
+        let mut matched_pane_ids: Vec<u32> = Vec::new();
+
+        for (bookmark_idx, bookmark) in self.pending_bookmarks.iter().enumerate() {
+            for (tab_position, panes) in &pane_manifest.panes {
+                if let Some(tab) = tab_infos.iter().find(|t| t.position == *tab_position) {
+                    if tab.name != bookmark.tab_name {
+                        continue;
+                    }
+                    for pane in panes {
+                        if pane.is_plugin {
+                            continue;
+                        }
+                        if pane.title != bookmark.pane_title {
+                            continue;
+                        }
+                        if current_pane_ids.contains(&pane.id) || matched_pane_ids.contains(&pane.id) {
+                            continue;
+                        }
+                        self.panes.push(Pane {
+                            pane_info: pane.clone(),
+                            tab_info: tab.clone(),
+                        });
+                        matched_pane_ids.push(pane.id);
+                        matched_indices.push(bookmark_idx);
+                        break;
+                    }
+                }
+                if matched_indices.last() == Some(&bookmark_idx) {
+                    break;
+                }
+            }
+        }
+
+        // Remove matched bookmarks in reverse order to preserve indices
+        for idx in matched_indices.into_iter().rev() {
+            self.pending_bookmarks.remove(idx);
+        }
+
+        if !matched_pane_ids.is_empty() {
+            self.sort_panes();
+        }
+    }
+
+    fn data_dir_path(&self) -> String {
+        "${XDG_DATA_HOME:-$HOME/.local/share}/harpoon".to_string()
+    }
+
+    fn session_file_path(&self) -> Option<String> {
+        let session = self.session_name.as_ref()?;
+        Some(format!("{}/{}.json", self.data_dir_path(), session))
+    }
+
+    fn load_from_disk(&self) {
+        let Some(file_path) = self.session_file_path() else {
+            return;
+        };
+        let cmd = format!("cat {} 2>/dev/null || echo '[]'", file_path);
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "load".to_string());
+        run_command(&["sh", "-c", &cmd], context);
+    }
+
+    fn save_to_disk(&self) {
+        let Some(file_path) = self.session_file_path() else {
+            return;
+        };
+        let bookmarks: Vec<PaneBookmark> = self
+            .panes
+            .iter()
+            .map(|p| PaneBookmark {
+                tab_name: p.tab_info.name.clone(),
+                pane_title: p.pane_info.title.clone(),
+            })
+            .collect();
+        let json = serde_json::to_string(&bookmarks).unwrap_or_else(|_| "[]".to_string());
+        // Escape single quotes for shell: ' → '\''
+        let escaped_json = json.replace('\'', "'\\''");
+        let cmd = format!(
+            "mkdir -p {} && printf '%s' '{}' > {}",
+            self.data_dir_path(),
+            escaped_json,
+            file_path,
+        );
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "save".to_string());
+        run_command(&["sh", "-c", &cmd], context);
+    }
 }
 
 register_plugin!(State);
@@ -177,6 +283,8 @@ impl ZellijPlugin for State {
             EventType::TabUpdate,
             EventType::PaneUpdate,
             EventType::PermissionRequestResult,
+            EventType::SessionUpdate,
+            EventType::RunCommandResult,
         ]);
     }
 
@@ -199,6 +307,26 @@ impl ZellijPlugin for State {
                 let plugin_ids = get_plugin_ids();
                 rename_plugin_pane(plugin_ids.plugin_id, "harpoon");
             }
+            Event::SessionUpdate(session_infos, _) => {
+                if self.session_name.is_none() {
+                    if let Some(current) = session_infos.iter().find(|s| s.is_current_session) {
+                        self.session_name = Some(current.name.clone());
+                        self.load_from_disk();
+                    }
+                }
+            }
+            Event::RunCommandResult(_exit_code, stdout, _stderr, context) => {
+                if context.get("source").map(|s| s.as_str()) == Some("load") {
+                    let content = String::from_utf8_lossy(&stdout);
+                    if let Ok(bookmarks) = serde_json::from_str::<Vec<PaneBookmark>>(&content) {
+                        self.pending_bookmarks = bookmarks;
+                        self.update_panes();
+                        should_render = true;
+                    } else {
+                        eprintln!("[harpoon] failed to parse saved bookmarks");
+                    }
+                }
+            }
             Event::Key(key) => match key.bare_key {
                 BareKey::Char('A') => {
                     // Add all terminal panes from all tabs that aren't already tracked
@@ -220,6 +348,7 @@ impl ZellijPlugin for State {
                         }
                     }
                     self.sort_panes();
+                    self.save_to_disk();
                     should_render = true;
                     hide_self();
                 }
@@ -231,6 +360,7 @@ impl ZellijPlugin for State {
                         if !self.panes.iter().any(|p| p.pane_info.id == pane.pane_info.id) {
                             self.panes.push(pane.clone());
                             self.sort_panes();
+                            self.save_to_disk();
                         }
                     }
                     should_render = true;
@@ -239,6 +369,7 @@ impl ZellijPlugin for State {
                 BareKey::Char('d') => {
                     if self.selected < self.panes.len() {
                         self.panes.remove(self.selected);
+                        self.save_to_disk();
                     }
                     self.clamp_selected();
                     should_render = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,11 @@ impl State {
         }
         self.clamp_selected();
 
+        if self.persistence.has_changed(&self.panes) {
+            self.persistence
+                .save_to_disk(&self.session_name, &self.panes);
+        }
+
         Some(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,9 @@ impl State {
                         if pane.title != bookmark.pane_title {
                             continue;
                         }
-                        if current_pane_ids.contains(&pane.id) || matched_pane_ids.contains(&pane.id) {
+                        if current_pane_ids.contains(&pane.id)
+                            || matched_pane_ids.contains(&pane.id)
+                        {
                             continue;
                         }
                         self.panes.push(Pane {
@@ -236,7 +238,7 @@ impl State {
         let Some(file_path) = self.session_file_path() else {
             return;
         };
-        let cmd = format!("cat {} 2>/dev/null || echo '[]'", file_path);
+        let cmd = format!("cat {file_path} 2>/dev/null || echo '[]'");
         let mut context = BTreeMap::new();
         context.insert("source".to_string(), "load".to_string());
         run_command(&["sh", "-c", &cmd], context);
@@ -478,7 +480,10 @@ fn build_narrow_hints() -> (String, Vec<std::ops::Range<usize>>) {
     build_hint_string(&parts, " ")
 }
 
-fn build_hint_string(parts: &[(&str, &str)], separator: &str) -> (String, Vec<std::ops::Range<usize>>) {
+fn build_hint_string(
+    parts: &[(&str, &str)],
+    separator: &str,
+) -> (String, Vec<std::ops::Range<usize>>) {
     let mut result = String::new();
     let mut key_ranges = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ impl State {
     }
 
     fn data_dir_path(&self) -> String {
-        "${XDG_DATA_HOME:-$HOME/.local/share}/harpoon".to_string()
+        "${XDG_DATA_HOME:-$HOME/.local/share}/zellij-harpoon".to_string()
     }
 
     fn session_file_path(&self) -> Option<String> {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,144 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use zellij_tile::prelude::*;
+
+use crate::Pane;
+
+#[derive(Clone, Serialize, Deserialize)]
+struct PaneBookmark {
+    tab_name: String,
+    pane_title: String,
+}
+
+#[derive(Default)]
+pub struct Persistence {
+    pending_bookmarks: Vec<PaneBookmark>,
+}
+
+#[derive(Debug)]
+pub enum PersistenceError {
+    LoadFromDiskFailed(serde_json::Error),
+}
+
+impl std::fmt::Display for PersistenceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PersistenceError::LoadFromDiskFailed(e) => {
+                write!(f, "Failed to load session from disk: {e:?}")
+            }
+        }
+    }
+}
+
+impl Persistence {
+    pub fn match_pending_bookmarks(
+        &mut self,
+        panes: &[Pane],
+        pane_manifest: &PaneManifest,
+        tab_infos: &[TabInfo],
+    ) -> Vec<Pane> {
+        if self.pending_bookmarks.is_empty() {
+            return Vec::new();
+        }
+
+        let current_pane_ids: Vec<u32> = panes.iter().map(|p| p.pane_info.id).collect();
+        let mut matched_indices = Vec::new();
+        let mut matched_pane_ids: Vec<u32> = Vec::new();
+        let mut new_panes = Vec::new();
+
+        for (bookmark_idx, bookmark) in self.pending_bookmarks.iter().enumerate() {
+            for (tab_position, panes) in &pane_manifest.panes {
+                if let Some(tab) = tab_infos.iter().find(|t| t.position == *tab_position) {
+                    if tab.name != bookmark.tab_name {
+                        continue;
+                    }
+                    for pane in panes {
+                        if pane.is_plugin {
+                            continue;
+                        }
+                        if pane.title != bookmark.pane_title {
+                            continue;
+                        }
+                        if current_pane_ids.contains(&pane.id)
+                            || matched_pane_ids.contains(&pane.id)
+                        {
+                            continue;
+                        }
+                        new_panes.push(Pane {
+                            pane_info: pane.clone(),
+                            tab_info: tab.clone(),
+                        });
+                        matched_pane_ids.push(pane.id);
+                        matched_indices.push(bookmark_idx);
+                        break;
+                    }
+                }
+                if matched_indices.last() == Some(&bookmark_idx) {
+                    break;
+                }
+            }
+        }
+
+        // Remove matched bookmarks in reverse order to preserve indices
+        for idx in matched_indices.into_iter().rev() {
+            self.pending_bookmarks.remove(idx);
+        }
+
+        new_panes
+    }
+
+    fn data_dir_path(&self) -> String {
+        "${XDG_DATA_HOME:-$HOME/.local/share}/zellij-harpoon".to_string()
+    }
+
+    fn session_file_path(&self, session_name: &Option<String>) -> Option<String> {
+        let session = session_name.as_ref()?;
+        Some(format!("{}/{}.json", self.data_dir_path(), session))
+    }
+
+    pub fn load_from_disk(&self, session_name: &Option<String>) {
+        let Some(file_path) = self.session_file_path(session_name) else {
+            return;
+        };
+        let cmd = format!("cat {file_path} 2>/dev/null || echo '[]'");
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "load".to_string());
+        run_command(&["sh", "-c", &cmd], context);
+    }
+
+    pub fn on_load_command(&mut self, content: &str) -> Result<(), PersistenceError> {
+        match serde_json::from_str::<Vec<PaneBookmark>>(content) {
+            Ok(bookmarks) => {
+                self.pending_bookmarks = bookmarks;
+                Ok(())
+            }
+            Err(e) => Err(PersistenceError::LoadFromDiskFailed(e)),
+        }
+    }
+
+    pub fn save_to_disk(&self, session_name: &Option<String>, panes: &[Pane]) {
+        let Some(file_path) = self.session_file_path(session_name) else {
+            return;
+        };
+        let bookmarks: Vec<PaneBookmark> = panes
+            .iter()
+            .map(|p| PaneBookmark {
+                tab_name: p.tab_info.name.clone(),
+                pane_title: p.pane_info.title.clone(),
+            })
+            .collect();
+        let json = serde_json::to_string(&bookmarks).unwrap_or_else(|_| "[]".to_string());
+        // Escape single quotes for shell: ' → '\''
+        let escaped_json = json.replace('\'', "'\\''");
+        let cmd = format!(
+            "mkdir -p {} && printf '%s' '{}' > {}",
+            self.data_dir_path(),
+            escaped_json,
+            file_path,
+        );
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "save".to_string());
+        run_command(&["sh", "-c", &cmd], context);
+    }
+}

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -129,16 +129,13 @@ impl Persistence {
             })
             .collect();
         let json = serde_json::to_string(&bookmarks).unwrap_or_else(|_| "[]".to_string());
-        // Escape single quotes for shell: ' → '\''
-        let escaped_json = json.replace('\'', "'\\''");
         let cmd = format!(
-            "mkdir -p {} && printf '%s' '{}' > {}",
+            "mkdir -p {} && printf '%s' \"$1\" > {}",
             self.data_dir_path(),
-            escaped_json,
             file_path,
         );
         let mut context = BTreeMap::new();
         context.insert("source".to_string(), "save".to_string());
-        run_command(&["sh", "-c", &cmd], context);
+        run_command(&["sh", "-c", &cmd, "_", &json], context);
     }
 }


### PR DESCRIPTION
This adds some basic persistence between plugin reloads and exiting Zellij as discussed in #16. 

The pinned panes are persisted to disk in a separate file per Zellij session On restart, bookmarks are matched back to live panes by tab name and pane title (and we sync on tab and pane updates). Storage is at `${XDG_DATA_HOME:-$HOME/.local/share}/zellij-harpoon/<session>.json`.

I did only some basic testing :)