### PR TITLE
Add cross-session pane navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 pub(crate) mod persistence;
 
 use core::fmt;
-use persistence::Persistence;
+use persistence::{Persistence, RemotePane};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -97,6 +97,25 @@ fn get_valid_panes(
     new_panes
 }
 
+/// An entry in the harpoon list — either a local pane (current session)
+/// or a remote bookmark (another session, not yet resolved to a live pane).
+#[derive(Clone)]
+enum HarpoonEntry {
+    Local(Pane),
+    Remote(RemotePane),
+}
+
+impl fmt::Display for HarpoonEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HarpoonEntry::Local(pane) => write!(f, "{} | {}", pane.tab_info.name, pane.pane_info.title),
+            HarpoonEntry::Remote(remote) => {
+                write!(f, "[{}] {} | {}", remote.session_name, remote.tab_name, remote.pane_title)
+            }
+        }
+    }
+}
+
 #[derive(Default)]
 struct State {
     selected: usize,
@@ -106,37 +125,38 @@ struct State {
     pane_manifest: Option<PaneManifest>,
     session_name: Option<String>,
     persistence: Persistence,
+    config_loaded: bool,
 }
 
 impl State {
     fn clamp_selected(&mut self) {
-        if self.panes.is_empty() {
+        let count = self.build_entries().len();
+        if count == 0 {
             self.selected = 0;
-        } else if self.selected >= self.panes.len() {
-            self.selected = self.panes.len() - 1;
+        } else if self.selected >= count {
+            self.selected = count - 1;
         }
-    }
-
-    fn select_down(&mut self) {
-        if self.panes.is_empty() {
-            return;
-        }
-        self.selected = (self.selected + 1) % self.panes.len();
-    }
-
-    fn select_up(&mut self) {
-        if self.panes.is_empty() {
-            return;
-        }
-        if self.selected == 0 {
-            self.selected = self.panes.len() - 1;
-            return;
-        }
-        self.selected -= 1;
     }
 
     fn sort_panes(&mut self) {
         self.panes.sort_by(|x, y| x.tab_info.position.cmp(&y.tab_info.position));
+    }
+
+    fn cross_session(&self) -> bool {
+        self.persistence.config.cross_session
+    }
+
+    /// Builds the list of entries to display, combining local panes
+    /// with remote panes when cross-session mode is active.
+    fn build_entries(&self) -> Vec<HarpoonEntry> {
+        let mut entries: Vec<HarpoonEntry> =
+            self.panes.iter().cloned().map(HarpoonEntry::Local).collect();
+        if self.cross_session() {
+            for remote in &self.persistence.remote_panes {
+                entries.push(HarpoonEntry::Remote(remote.clone()));
+            }
+        }
+        entries
     }
 
     /// Reconciles the stored pane list against the latest manifest and updates
@@ -185,7 +205,13 @@ impl State {
 register_plugin!(State);
 
 impl ZellijPlugin for State {
-    fn load(&mut self, _: BTreeMap<String, String>) {
+    fn load(&mut self, config: BTreeMap<String, String>) {
+        // Layout config provides the initial default for cross_session
+        // before the persisted config.json is loaded.
+        if let Some(val) = config.get("cross_session") {
+            self.persistence.config.cross_session = val == "true";
+        }
+
         request_permission(&[
             PermissionType::RunCommands,
             PermissionType::ReadApplicationState,
@@ -219,6 +245,7 @@ impl ZellijPlugin for State {
                 // rename_plugin_pane requires ChangeApplicationState permission.
                 let plugin_ids = get_plugin_ids();
                 rename_plugin_pane(plugin_ids.plugin_id, "harpoon");
+                self.persistence.load_config();
             }
             Event::SessionUpdate(session_infos, _) => {
                 if self.session_name.is_none() {
@@ -229,17 +256,36 @@ impl ZellijPlugin for State {
                 }
             }
             Event::RunCommandResult(_exit_code, stdout, _stderr, context) => {
-                if context.get("source").map(|s| s.as_str()) == Some("load") {
-                    let content = String::from_utf8_lossy(&stdout);
-                    match self.persistence.on_load_command(&content) {
-                        Ok(_) => {
-                            self.update_panes();
-                            should_render = true;
-                        }
-                        Err(e) => {
-                            eprintln!("{e}");
+                let source = context.get("source").map(|s| s.as_str());
+                match source {
+                    Some("load") => {
+                        let content = String::from_utf8_lossy(&stdout);
+                        match self.persistence.on_load_command(&content) {
+                            Ok(_) => {
+                                self.update_panes();
+                                should_render = true;
+                            }
+                            Err(e) => {
+                                eprintln!("{e}");
+                            }
                         }
                     }
+                    Some("load_config") => {
+                        let content = String::from_utf8_lossy(&stdout);
+                        let was_cross = self.cross_session();
+                        self.persistence.on_load_config_command(&content);
+                        self.config_loaded = true;
+                        if self.cross_session() && !was_cross {
+                            self.persistence.load_remote_panes(&self.session_name);
+                        }
+                        should_render = true;
+                    }
+                    Some("load_remote") => {
+                        let content = String::from_utf8_lossy(&stdout);
+                        self.persistence.on_load_remote_command(&content);
+                        should_render = true;
+                    }
+                    _ => {}
                 }
             }
             Event::Key(key) => match key.bare_key {
@@ -284,10 +330,32 @@ impl ZellijPlugin for State {
                     hide_self();
                 }
                 BareKey::Char('d') => {
-                    if self.selected < self.panes.len() {
-                        self.panes.remove(self.selected);
-                        self.persistence
-                            .save_to_disk(&self.session_name, &self.panes);
+                    let entries = self.build_entries();
+                    if let Some(entry) = entries.get(self.selected) {
+                        match entry {
+                            HarpoonEntry::Local(_) => {
+                                // selected index maps directly to panes when it's within range
+                                if self.selected < self.panes.len() {
+                                    self.panes.remove(self.selected);
+                                    self.persistence
+                                        .save_to_disk(&self.session_name, &self.panes);
+                                }
+                            }
+                            HarpoonEntry::Remote(_) => {
+                                // Remote entries are read-only — cannot delete from here
+                            }
+                        }
+                    }
+                    self.clamp_selected();
+                    should_render = true;
+                }
+                BareKey::Char('s') => {
+                    self.persistence.config.cross_session = !self.persistence.config.cross_session;
+                    self.persistence.save_config();
+                    if self.cross_session() {
+                        self.persistence.load_remote_panes(&self.session_name);
+                    } else {
+                        self.persistence.remote_panes.clear();
                     }
                     self.clamp_selected();
                     should_render = true;
@@ -296,22 +364,40 @@ impl ZellijPlugin for State {
                     hide_self();
                 }
                 BareKey::Down | BareKey::Char('j') => {
-                    if self.panes.len() > 0 {
-                        self.select_down();
+                    let count = self.build_entries().len();
+                    if count > 0 {
+                        self.selected = (self.selected + 1) % count;
                         should_render = true;
                     }
                 }
                 BareKey::Up | BareKey::Char('k') => {
-                    if self.panes.len() > 0 {
-                        self.select_up();
+                    let count = self.build_entries().len();
+                    if count > 0 {
+                        if self.selected == 0 {
+                            self.selected = count - 1;
+                        } else {
+                            self.selected -= 1;
+                        }
                         should_render = true;
                     }
                 }
                 BareKey::Enter | BareKey::Char('l') => {
-                    if let Some(pane) = self.panes.get(self.selected) {
+                    let entries = self.build_entries();
+                    if let Some(entry) = entries.get(self.selected) {
                         hide_self();
-                        // TODO: This has a bug on macOS with hidden panes
-                        focus_terminal_pane(pane.pane_info.id, true);
+                        match entry {
+                            HarpoonEntry::Local(pane) => {
+                                // TODO: This has a bug on macOS with hidden panes
+                                focus_terminal_pane(pane.pane_info.id, true);
+                            }
+                            HarpoonEntry::Remote(remote) => {
+                                switch_session_with_focus(
+                                    &remote.session_name,
+                                    None,
+                                    None,
+                                );
+                            }
+                        }
                     }
                 }
                 _ => (),
@@ -323,36 +409,43 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, rows: usize, cols: usize) {
+        let entries = self.build_entries();
+
         // Note: y=0 overlaps with the zellij pane frame/title bar and is not visible,
         // so we start rendering from y=1.
-        let header = format!("==== {} panes ====", self.panes.len());
+        let header = if self.cross_session() {
+            format!("==== {} panes (all sessions) ====", entries.len())
+        } else {
+            format!("==== {} panes ====", entries.len())
+        };
         let x = cols.saturating_sub(header.len()) / 2;
         print_text_with_coordinates(Text::new(&header), x, 0, None, None);
         let mut y = 1;
 
-        for (idx, pane) in self.panes.iter().enumerate() {
+        for (idx, entry) in entries.iter().enumerate() {
             let text = if idx == self.selected {
-                Text::new(&pane.to_string()).selected()
+                Text::new(&entry.to_string()).selected()
             } else {
-                Text::new(&pane.to_string())
+                Text::new(&entry.to_string())
             };
             print_text_with_coordinates(text, 0, y, None, None);
             y += 1;
         }
 
         let hint_y = rows.saturating_sub(1);
-        let hint_line = build_hint_line(cols);
+        let hint_line = build_hint_line(cols, self.cross_session());
         print_text_with_coordinates(hint_line, 0, hint_y, None, None);
     }
 }
 
-fn build_hint_line(cols: usize) -> Text {
+fn build_hint_line(cols: usize, cross_session: bool) -> Text {
+    let session_label = if cross_session { " on" } else { " off" };
     let (line, key_ranges) = if cols > 75 {
-        build_wide_hints()
+        build_wide_hints(session_label)
     } else if cols > 50 {
-        build_medium_hints()
+        build_medium_hints(session_label)
     } else {
-        build_narrow_hints()
+        build_narrow_hints(session_label)
     };
 
     let mut text = Text::new(&line);
@@ -362,11 +455,13 @@ fn build_hint_line(cols: usize) -> Text {
     text
 }
 
-fn build_wide_hints() -> (String, Vec<std::ops::Range<usize>>) {
+fn build_wide_hints(session_label: &str) -> (String, Vec<std::ops::Range<usize>>) {
+    let session_hint = format!(" sessions{session_label}");
     let parts = [
         ("<a>", " add pane"),
         ("<A>", " add all"),
         ("<d>", " delete"),
+        ("<s>", session_hint.as_str()),
         ("<j/k>", " navigate"),
         ("<Enter>", " focus"),
         ("<Esc>", " close"),
@@ -374,11 +469,13 @@ fn build_wide_hints() -> (String, Vec<std::ops::Range<usize>>) {
     build_hint_string(&parts, ", ")
 }
 
-fn build_medium_hints() -> (String, Vec<std::ops::Range<usize>>) {
+fn build_medium_hints(session_label: &str) -> (String, Vec<std::ops::Range<usize>>) {
+    let session_hint = format!(" sess{session_label}");
     let parts = [
         ("<a>", " add"),
         ("<A>", " all"),
         ("<d>", " del"),
+        ("<s>", session_hint.as_str()),
         ("<j/k>", " nav"),
         ("<Enter>", " go"),
         ("<Esc>", " quit"),
@@ -386,10 +483,12 @@ fn build_medium_hints() -> (String, Vec<std::ops::Range<usize>>) {
     build_hint_string(&parts, ", ")
 }
 
-fn build_narrow_hints() -> (String, Vec<std::ops::Range<usize>>) {
+fn build_narrow_hints(session_label: &str) -> (String, Vec<std::ops::Range<usize>>) {
+    let session_hint = format!("{session_label}");
     let parts = [
         ("<a>", " add"),
         ("<d>", " del"),
+        ("<s>", session_hint.as_str()),
         ("<Enter>", " go"),
         ("<Esc>", ""),
     ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -349,7 +349,7 @@ impl ZellijPlugin for State {
                     self.clamp_selected();
                     should_render = true;
                 }
-                BareKey::Char('s') => {
+                BareKey::Char('s') if key.has_modifiers(&[KeyModifier::Ctrl]) => {
                     self.persistence.config.cross_session = !self.persistence.config.cross_session;
                     self.persistence.save_config();
                     if self.cross_session() {
@@ -461,7 +461,7 @@ fn build_wide_hints(session_label: &str) -> (String, Vec<std::ops::Range<usize>>
         ("<a>", " add pane"),
         ("<A>", " add all"),
         ("<d>", " delete"),
-        ("<s>", session_hint.as_str()),
+        ("<C-s>", session_hint.as_str()),
         ("<j/k>", " navigate"),
         ("<Enter>", " focus"),
         ("<Esc>", " close"),
@@ -475,7 +475,7 @@ fn build_medium_hints(session_label: &str) -> (String, Vec<std::ops::Range<usize
         ("<a>", " add"),
         ("<A>", " all"),
         ("<d>", " del"),
-        ("<s>", session_hint.as_str()),
+        ("<C-s>", session_hint.as_str()),
         ("<j/k>", " nav"),
         ("<Enter>", " go"),
         ("<Esc>", " quit"),
@@ -488,7 +488,7 @@ fn build_narrow_hints(session_label: &str) -> (String, Vec<std::ops::Range<usize
     let parts = [
         ("<a>", " add"),
         ("<d>", " del"),
-        ("<s>", session_hint.as_str()),
+        ("<C-s>", session_hint.as_str()),
         ("<Enter>", " go"),
         ("<Esc>", ""),
     ];

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -11,10 +11,26 @@ struct PaneBookmark {
     pane_title: String,
 }
 
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct HarpoonConfig {
+    #[serde(default)]
+    pub cross_session: bool,
+}
+
+/// A pane loaded from another session's bookmark file.
+#[derive(Clone)]
+pub struct RemotePane {
+    pub session_name: String,
+    pub tab_name: String,
+    pub pane_title: String,
+}
+
 #[derive(Default)]
 pub struct Persistence {
     pending_bookmarks: Vec<PaneBookmark>,
     last_saved_state: Vec<(String, String)>,
+    pub config: HarpoonConfig,
+    pub remote_panes: Vec<RemotePane>,
 }
 
 #[derive(Debug)]
@@ -99,6 +115,72 @@ impl Persistence {
                 Ok(())
             }
             Err(e) => Err(PersistenceError::LoadFromDiskFailed(e)),
+        }
+    }
+
+    pub fn load_config(&self) {
+        let cmd = format!(
+            "cat {}/config.json 2>/dev/null || echo '{{}}'",
+            self.data_dir_path()
+        );
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "load_config".to_string());
+        run_command(&["sh", "-c", &cmd], context);
+    }
+
+    pub fn on_load_config_command(&mut self, content: &str) {
+        self.config = serde_json::from_str::<HarpoonConfig>(content).unwrap_or_default();
+    }
+
+    pub fn save_config(&self) {
+        let json =
+            serde_json::to_string(&self.config).unwrap_or_else(|_| "{}".to_string());
+        let cmd = format!(
+            "mkdir -p {} && printf '%s' \"$1\" > {}/config.json",
+            self.data_dir_path(),
+            self.data_dir_path(),
+        );
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "save_config".to_string());
+        run_command(&["sh", "-c", &cmd, "_", &json], context);
+    }
+
+    pub fn load_remote_panes(&self, current_session: &Option<String>) {
+        let current = current_session.as_deref().unwrap_or("");
+        let cmd = format!(
+            "for f in {dir}/*.json; do \
+                name=\"$(basename \"$f\" .json)\"; \
+                [ \"$name\" = \"config\" ] && continue; \
+                [ \"$name\" = \"{current}\" ] && continue; \
+                echo \"SESSION:$name\"; \
+                cat \"$f\"; \
+                echo; \
+            done 2>/dev/null || true",
+            dir = self.data_dir_path(),
+            current = current,
+        );
+        let mut context = BTreeMap::new();
+        context.insert("source".to_string(), "load_remote".to_string());
+        run_command(&["sh", "-c", &cmd], context);
+    }
+
+    pub fn on_load_remote_command(&mut self, content: &str) {
+        self.remote_panes.clear();
+        let mut current_session = String::new();
+        for line in content.lines() {
+            if let Some(name) = line.strip_prefix("SESSION:") {
+                current_session = name.to_string();
+            } else if !line.is_empty() && !current_session.is_empty() {
+                if let Ok(bookmarks) = serde_json::from_str::<Vec<PaneBookmark>>(line) {
+                    for b in bookmarks {
+                        self.remote_panes.push(RemotePane {
+                            session_name: current_session.clone(),
+                            tab_name: b.tab_name,
+                            pane_title: b.pane_title,
+                        });
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds optional cross-session mode that displays pinned panes from all Zellij sessions
- `<s>` key toggles between session-local (default) and cross-session view
- Selecting a remote pane calls `switch_session_with_focus` to jump directly to that session
- Toggle state persists globally in `config.json` (shared across all sessions)
- Default behavior is completely unchanged — cross-session is opt-in

## Design decisions

- **No breaking changes**: existing per-session `{session}.json` files are untouched
- **Global config**: stored at `~/.local/share/zellij-harpoon/config.json`, separate from session bookmarks
- **Layout support**: `cross_session` can also be set via Zellij plugin config as initial default
- **Remote panes are read-only**: `<d>` only deletes local panes, not entries from other sessions
- **Display**: remote panes shown as `[session] tab | pane` to distinguish from local ones

## Test plan

- [ ] Open harpoon in a session — verify default behavior is unchanged (session-local only)
- [ ] Press `<s>` — verify hint bar shows "sessions on" and panes from other sessions appear
- [ ] Press `<s>` again — verify it toggles back to session-local
- [ ] Close and reopen harpoon — verify toggle state persists
- [ ] Open harpoon in a different session — verify same toggle state
- [ ] Select a remote pane and press Enter — verify it switches to that session
- [ ] Try `<d>` on a remote pane — verify it does nothing
- [ ] Set `cross_session true` in Zellij layout config — verify it acts as initial default