### PR TITLE
feat: add recent sort mode (sort panes by last accessed time)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "harpoon-worker"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "zellij-tile",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,4 @@
-[package]
-name = "harpoon"
-version = "0.1.0"
-edition = "2021"
-authors = ["Ignacio Aleman <onsen@duck.com>"]
+[workspace]
+members = ["harpoon", "harpoon-worker"]
+resolver = "2"
 
-[dependencies]
-serde = "1.0.175"
-serde_json = "1.0.103"
-zellij-tile = "0.42.2"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ git clone git@github.com:Nacho114/harpoon.git
 cd harpoon
 cargo build --release
 mkdir -p ~/.config/zellij/plugins/
-mv target/wasm32-wasip1/release/harpoon.wasm ~/.config/zellij/plugins/
+cp target/wasm32-wasip1/release/harpoon.wasm ~/.config/zellij/plugins/
+cp target/wasm32-wasip1/release/harpoon-worker.wasm ~/.config/zellij/plugins/
 ```
 
 ## Keybinding
@@ -56,6 +57,40 @@ shared_except "locked" {
 ```
 
 > You likely already have a `shared_except "locked"` section in your configs. Feel free to add `bind` there.
+
+## Recent Sort Mode
+
+Enable `recent_sort` to sort the pane list by last accessed time (like JetBrains' Recent Files). The current focused pane is hidden from the list, so the first item is always your previous pane.
+
+```kdl
+shared_except "locked" {
+    bind "Ctrl y" {
+        LaunchOrFocusPlugin "file:~/.config/zellij/plugins/harpoon.wasm" {
+            floating true; move_to_focused_tab true;
+            recent_sort "true"
+        }
+    }
+}
+```
+
+This mode requires the **harpoon-worker** background plugin to track pane focus changes while harpoon is closed. Add it to your layout as a hidden pane:
+
+```kdl
+// In your layout file (e.g. ~/.config/zellij/layouts/default.kdl)
+pane size=1 borderless=true {
+    plugin location="file:~/.config/zellij/plugins/harpoon-worker.wasm"
+}
+```
+
+Or load it in your zellij config startup:
+
+```kdl
+load_plugins {
+    "file:~/.config/zellij/plugins/harpoon-worker.wasm"
+}
+```
+
+The worker continuously monitors which pane has focus and writes timestamps to `~/.local/share/zellij-harpoon/{session}-timestamps.json`. When harpoon opens, it reads this file to sort panes by recency.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ Copy of the original [harpoon](https://github.com/ThePrimeagen/harpoon) for nvim
 - `Up` and `Down` or `j` and `k` to cycle through pane list
 - `d` to remove pane from list
 - `Enter` or `l` to switch to the selected pane
+- `/` to enter search mode
 - `Esc` or `Ctrl + c` to exit
+
+### Fuzzy Search
+
+Press `/` to enter search mode. Type characters to fuzzy-match against pane tab names and titles (characters must appear in order but not necessarily contiguous). Matched characters are highlighted in the list.
+
+In search mode:
+- `Up` / `Down` to navigate filtered results
+- `Enter` to jump to the selected pane
+- `Backspace` to delete characters (exits search mode when empty)
+- `Esc` to cancel search and return to normal mode
 
 ## Why?
 

--- a/doc/source-analysis.md
+++ b/doc/source-analysis.md
@@ -1,0 +1,229 @@
+# Harpoon Zellij 插件源码分析
+
+## 项目概述
+
+Harpoon 是一个 Zellij 终端复用器的 WASM 插件，灵感来自 Neovim 的 [harpoon](https://github.com/ThePrimeagen/harpoon) 插件。它允许用户手动管理一个"收藏面板"列表，实现在常用 pane 之间快速跳转。
+
+## 项目结构
+
+```
+harpoon/
+├── src/
+│   ├── main.rs          # 插件主逻辑（状态管理、事件处理、UI 渲染）
+│   └── persistence.rs   # 持久化模块（书签的磁盘读写与恢复匹配）
+├── Cargo.toml           # 依赖：serde, serde_json, zellij-tile
+├── plugin-dev-workspace.kdl  # 开发用 Zellij 布局
+└── .cargo/config.toml   # 构建目标配置
+```
+
+## 核心依赖
+
+| 依赖 | 用途 |
+|------|------|
+| `zellij-tile` (0.42.2) | Zellij 插件 SDK，提供事件订阅、权限请求、UI 渲染等 API |
+| `serde` / `serde_json` | 书签数据的序列化与反序列化 |
+
+## 数据模型
+
+### `Pane`（main.rs）
+
+```rust
+struct Pane {
+    pane_info: PaneInfo,  // Zellij 提供的面板信息（id, title, is_plugin 等）
+    tab_info: TabInfo,    // 面板所属的标签页信息（name, position, active 等）
+}
+```
+
+- `PaneInfo.id` 对于非插件面板在整个 session 中唯一，是面板的稳定标识符。
+- `Display` trait 实现格式：`tab_name | pane_title`。
+
+### `PaneBookmark`（persistence.rs）
+
+```rust
+struct PaneBookmark {
+    tab_name: String,
+    pane_title: String,
+}
+```
+
+持久化到磁盘的轻量级书签，仅保存名称信息用于跨 session 恢复匹配。
+
+### `State`（main.rs）
+
+```rust
+struct State {
+    selected: usize,              // 当前选中的列表索引
+    panes: Vec<Pane>,             // 收藏的面板列表
+    focused_pane: Option<Pane>,   // 用户打开 harpoon 前聚焦的面板
+    tab_info: Option<Vec<TabInfo>>,
+    pane_manifest: Option<PaneManifest>,
+    session_name: Option<String>,
+    persistence: Persistence,
+}
+```
+
+## 执行流程
+
+### 1. 插件加载（`load`）
+
+```
+用户按下快捷键 (如 Ctrl+y)
+  → Zellij 加载 harpoon.wasm
+  → 调用 State::load()
+    → 请求权限：RunCommands, ReadApplicationState, ChangeApplicationState
+    → 订阅事件：Key, TabUpdate, PaneUpdate, PermissionRequestResult,
+                SessionUpdate, RunCommandResult
+```
+
+### 2. 初始化序列
+
+插件加载后，Zellij 会依次推送事件完成初始化：
+
+```
+PermissionRequestResult(Granted)
+  → 重命名插件面板为 "harpoon"
+
+SessionUpdate(session_infos)
+  → 获取当前 session 名称
+  → 触发 load_from_disk()：执行 shell 命令读取持久化文件
+
+RunCommandResult (source="load")
+  → 解析 JSON 为 Vec<PaneBookmark>
+  → 存入 pending_bookmarks 等待与实际面板匹配
+
+TabUpdate / PaneUpdate
+  → 缓存最新的 tab_info / pane_manifest
+  → 调用 update_panes() 进行面板同步
+```
+
+### 3. 面板同步（`update_panes`）
+
+每次收到 `TabUpdate` 或 `PaneUpdate` 时执行：
+
+```
+update_panes()
+  ├── get_valid_panes()
+  │     遍历已保存面板，在最新 manifest 中按 pane_id 查找
+  │     移除已关闭的面板，更新已移动面板的 tab 信息
+  │
+  ├── match_pending_bookmarks()
+  │     将磁盘加载的书签按 (tab_name, pane_title) 匹配到实际面板
+  │     匹配成功的从 pending 列表移除，加入 panes 列表
+  │
+  ├── 更新 focused_pane（当前活跃的非插件面板）
+  │
+  ├── 将 selected 光标移到 focused_pane 对应的列表位置
+  │
+  └── 如果列表有变化，save_to_disk() 持久化
+```
+
+### 4. 用户交互（键盘事件）
+
+| 按键 | 行为 |
+|------|------|
+| `a` | 将当前聚焦面板加入列表，按 tab 位置排序后隐藏插件 |
+| `A` | 将所有标签页的所有终端面板加入列表，隐藏插件 |
+| `d` | 删除选中项，持久化保存 |
+| `j` / `Down` | 选中项下移（循环） |
+| `k` / `Up` | 选中项上移（循环） |
+| `Enter` / `l` | 跳转到选中面板（`focus_terminal_pane`），隐藏插件 |
+| `Esc` / `c` | 隐藏插件 |
+
+### 5. UI 渲染（`render`）
+
+```
+render(rows, cols)
+  ├── 居中显示标题 "==== N panes ===="
+  ├── 逐行渲染面板列表，选中项高亮（.selected()）
+  └── 底部显示快捷键提示（根据窗口宽度自适应 3 种布局）
+```
+
+提示栏根据列宽选择不同详细程度：
+- `> 75` 列：完整提示
+- `> 50` 列：缩写提示
+- `≤ 50` 列：最简提示
+
+## 持久化机制
+
+### 存储路径
+
+```
+$XDG_DATA_HOME/zellij-harpoon/<session_name>.json
+# 默认: ~/.local/share/zellij-harpoon/<session_name>.json
+```
+
+### 读取流程
+
+```
+load_from_disk()
+  → run_command(["sh", "-c", "cat <path> 2>/dev/null || echo '[]'"])
+  → 异步等待 RunCommandResult 事件
+  → on_load_command() 解析 JSON → pending_bookmarks
+```
+
+### 写入流程
+
+```
+save_to_disk()
+  → 将 panes 转为 Vec<PaneBookmark> → JSON
+  → run_command(["sh", "-c", "mkdir -p <dir> && printf '%s' \"$1\" > <path>", "_", json])
+```
+
+### 变更检测
+
+`has_changed()` 比较当前面板列表的 `(tab_name, pane_title)` 元组与上次保存的状态，避免无意义的磁盘写入。
+
+### 恢复匹配
+
+`match_pending_bookmarks()` 在每次 `update_panes()` 时尝试将未匹配的书签与实际面板关联：
+- 按 `tab_name` 找到对应标签页
+- 在该标签页中按 `pane_title` 找到匹配的非插件面板
+- 避免重复匹配已在列表中的面板
+
+## 完整生命周期时序图
+
+```
+┌─────────┐     ┌─────────┐     ┌──────────────┐     ┌──────┐
+│  User   │     │ Zellij  │     │   Harpoon    │     │ Disk │
+└────┬────┘     └────┬────┘     └──────┬───────┘     └──┬───┘
+     │  Ctrl+y       │                 │                 │
+     │──────────────>│  load()         │                 │
+     │               │────────────────>│                 │
+     │               │  PermGranted    │                 │
+     │               │────────────────>│ rename pane     │
+     │               │  SessionUpdate  │                 │
+     │               │────────────────>│ load_from_disk  │
+     │               │                 │────────────────>│
+     │               │  RunCmdResult   │                 │
+     │               │────────────────>│ parse bookmarks │
+     │               │  TabUpdate      │                 │
+     │               │────────────────>│ update_panes()  │
+     │               │  PaneUpdate     │                 │
+     │               │────────────────>│ update_panes()  │
+     │               │                 │ match bookmarks │
+     │               │  render()       │                 │
+     │               │<────────────────│                 │
+     │  显示 UI      │                 │                 │
+     │<──────────────│                 │                 │
+     │  按 'a'       │                 │                 │
+     │──────────────>│  Key('a')       │                 │
+     │               │────────────────>│ add pane        │
+     │               │                 │ save_to_disk    │
+     │               │                 │────────────────>│
+     │               │                 │ hide_self()     │
+     │               │<────────────────│                 │
+     │  按 Enter     │                 │                 │
+     │──────────────>│  Key(Enter)     │                 │
+     │               │────────────────>│ focus_pane      │
+     │               │                 │ hide_self()     │
+     │<──────────────│<────────────────│                 │
+     │  切换到目标面板│                 │                 │
+```
+
+## 设计要点
+
+1. **面板标识**：使用 `PaneInfo.id`（非插件面板在 session 内唯一）作为运行时标识，使用 `(tab_name, pane_title)` 作为持久化标识。
+2. **异步 I/O**：WASM 环境无法直接访问文件系统，通过 `run_command` 执行 shell 命令实现异步读写。
+3. **自动清理**：每次事件更新时自动移除已关闭的面板，保持列表与实际状态同步。
+4. **跨 session 恢复**：通过名称匹配（而非 ID）实现 session 重启后的书签恢复。
+5. **最小权限**：仅请求必要的三项权限（RunCommands、ReadApplicationState、ChangeApplicationState）。

--- a/harpoon-worker/Cargo.toml
+++ b/harpoon-worker/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "harpoon-worker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0.175"
+serde_json = "1.0.103"
+zellij-tile = "0.42.2"

--- a/harpoon-worker/src/main.rs
+++ b/harpoon-worker/src/main.rs
@@ -1,0 +1,171 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use zellij_tile::prelude::*;
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Map of (tab_name, pane_title) -> last_accessed timestamp.
+/// We use tab_name+pane_title as key since pane IDs are not stable across sessions.
+#[derive(Default, Serialize, Deserialize)]
+struct TimestampMap {
+    entries: Vec<TimestampEntry>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct TimestampEntry {
+    tab_name: String,
+    pane_title: String,
+    #[serde(default)]
+    pane_id: u32,
+    last_accessed: u64,
+}
+
+#[derive(Default)]
+struct State {
+    tab_info: Option<Vec<TabInfo>>,
+    pane_manifest: Option<PaneManifest>,
+    session_name: Option<String>,
+    last_focused_id: Option<u32>,
+    timestamps: TimestampMap,
+}
+
+impl State {
+    fn data_dir() -> String {
+        "${XDG_DATA_HOME:-$HOME/.local/share}/zellij-harpoon".to_string()
+    }
+
+    fn timestamps_file(session_name: &str) -> String {
+        format!("{}/{}-timestamps.json", Self::data_dir(), session_name)
+    }
+
+    fn save_timestamps(&self) {
+        let Some(session) = &self.session_name else { return };
+        let json = serde_json::to_string(&self.timestamps).unwrap_or_default();
+        let file_path = Self::timestamps_file(session);
+        let cmd = format!(
+            "mkdir -p {} && printf '%s' \"$1\" > {}",
+            Self::data_dir(),
+            file_path,
+        );
+        let mut ctx = BTreeMap::new();
+        ctx.insert("source".to_string(), "save".to_string());
+        run_command(&["sh", "-c", &cmd, "_", &json], ctx);
+    }
+
+    fn update_focus(&mut self) {
+        let tab_info = match &self.tab_info {
+            Some(t) => t,
+            None => return,
+        };
+        let pane_manifest = match &self.pane_manifest {
+            Some(p) => p,
+            None => return,
+        };
+
+        let focused_tab = match tab_info.iter().find(|t| t.active) {
+            Some(t) => t,
+            None => return,
+        };
+
+        let panes = match pane_manifest.panes.get(&focused_tab.position) {
+            Some(p) => p,
+            None => return,
+        };
+
+        // Find the focused terminal pane
+        let focused_pane = panes.iter().find(|p| p.is_focused && !p.is_plugin)
+            .or_else(|| panes.iter().find(|p| !p.is_plugin));
+
+        let Some(focused_pane) = focused_pane else { return };
+
+        // Only update if focus actually changed
+        if self.last_focused_id == Some(focused_pane.id) {
+            return;
+        }
+        self.last_focused_id = Some(focused_pane.id);
+
+        let tab_name = &focused_tab.name;
+        let pane_title = &focused_pane.title;
+        let pane_id = focused_pane.id;
+        let ts = now_secs();
+
+        // Update or insert, matching by pane_id first
+        if let Some(entry) = self.timestamps.entries.iter_mut().find(|e| e.pane_id == pane_id) {
+            entry.last_accessed = ts;
+            entry.tab_name = tab_name.clone();
+            entry.pane_title = pane_title.clone();
+        } else {
+            self.timestamps.entries.push(TimestampEntry {
+                tab_name: tab_name.clone(),
+                pane_title: pane_title.clone(),
+                pane_id,
+                last_accessed: ts,
+            });
+        }
+
+        self.save_timestamps();
+    }
+}
+
+register_plugin!(State);
+
+impl ZellijPlugin for State {
+    fn load(&mut self, _: BTreeMap<String, String>) {
+        request_permission(&[
+            PermissionType::RunCommands,
+            PermissionType::ReadApplicationState,
+        ]);
+        subscribe(&[
+            EventType::TabUpdate,
+            EventType::PaneUpdate,
+            EventType::SessionUpdate,
+            EventType::RunCommandResult,
+        ]);
+    }
+
+    fn update(&mut self, event: Event) -> bool {
+        match event {
+            Event::TabUpdate(tab_info) => {
+                self.tab_info = Some(tab_info);
+                self.update_focus();
+            }
+            Event::PaneUpdate(pane_manifest) => {
+                self.pane_manifest = Some(pane_manifest);
+                self.update_focus();
+            }
+            Event::SessionUpdate(session_infos, _) => {
+                if self.session_name.is_none() {
+                    if let Some(current) = session_infos.iter().find(|s| s.is_current_session) {
+                        self.session_name = Some(current.name.clone());
+                        // Load existing timestamps
+                        let file_path = Self::timestamps_file(&current.name);
+                        let cmd = format!("cat {} 2>/dev/null || echo '{{}}'", file_path);
+                        let mut ctx = BTreeMap::new();
+                        ctx.insert("source".to_string(), "load".to_string());
+                        run_command(&["sh", "-c", &cmd], ctx);
+                    }
+                }
+            }
+            Event::RunCommandResult(_exit_code, stdout, _stderr, context) => {
+                if context.get("source").map(|s| s.as_str()) == Some("load") {
+                    let content = String::from_utf8_lossy(&stdout);
+                    if let Ok(map) = serde_json::from_str::<TimestampMap>(&content) {
+                        self.timestamps = map;
+                    }
+                }
+            }
+            _ => {}
+        }
+        false // never needs rendering
+    }
+
+    fn render(&mut self, _rows: usize, _cols: usize) {
+        // Worker is invisible, no rendering needed
+    }
+}

--- a/harpoon-worker/src/main.rs
+++ b/harpoon-worker/src/main.rs
@@ -6,7 +6,7 @@ use zellij_tile::prelude::*;
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
 
@@ -33,6 +33,7 @@ struct State {
     session_name: Option<String>,
     last_focused_id: Option<u32>,
     timestamps: TimestampMap,
+    debug: bool,
 }
 
 impl State {
@@ -42,6 +43,29 @@ impl State {
 
     fn timestamps_file(session_name: &str) -> String {
         format!("{}/{}-timestamps.json", Self::data_dir(), session_name)
+    }
+
+    fn log_file(session_name: &str) -> String {
+        format!("{}/{}-debug.log", Self::data_dir(), session_name)
+    }
+
+    fn debug_log(&self, msg: &str) {
+        if !self.debug {
+            return;
+        }
+        let Some(session) = &self.session_name else { return };
+        let log_path = Self::log_file(session);
+        let ts = now_secs();
+        let line = format!("[{}] {}", ts, msg);
+        let cmd = format!(
+            "mkdir -p {} && echo '{}' >> {}",
+            Self::data_dir(),
+            line,
+            log_path,
+        );
+        let mut ctx = BTreeMap::new();
+        ctx.insert("source".to_string(), "log".to_string());
+        run_command(&["sh", "-c", &cmd], ctx);
     }
 
     fn save_timestamps(&self) {
@@ -95,12 +119,21 @@ impl State {
         let pane_id = focused_pane.id;
         let ts = now_secs();
 
-        // Update or insert, matching by pane_id first
-        if let Some(entry) = self.timestamps.entries.iter_mut().find(|e| e.pane_id == pane_id) {
+        self.debug_log(&format!(
+            "focus changed: pane_id={} tab=\"{}\" title=\"{}\" ts={}",
+            pane_id, tab_name, pane_title, ts
+        ));
+
+        // Update or insert, matching by pane_id first (skip legacy entries with pane_id=0)
+        if let Some(entry) = self.timestamps.entries.iter_mut().find(|e| e.pane_id != 0 && e.pane_id == pane_id) {
             entry.last_accessed = ts;
             entry.tab_name = tab_name.clone();
             entry.pane_title = pane_title.clone();
         } else {
+            // Remove stale legacy entry with same tab_name+pane_title
+            self.timestamps.entries.retain(|e| {
+                !(e.pane_id == 0 && e.tab_name == *tab_name && e.pane_title == *pane_title)
+            });
             self.timestamps.entries.push(TimestampEntry {
                 tab_name: tab_name.clone(),
                 pane_title: pane_title.clone(),
@@ -116,7 +149,11 @@ impl State {
 register_plugin!(State);
 
 impl ZellijPlugin for State {
-    fn load(&mut self, _: BTreeMap<String, String>) {
+    fn load(&mut self, configuration: BTreeMap<String, String>) {
+        self.debug = configuration
+            .get("debug")
+            .map(|v| v == "true")
+            .unwrap_or(false);
         request_permission(&[
             PermissionType::RunCommands,
             PermissionType::ReadApplicationState,

--- a/harpoon/Cargo.toml
+++ b/harpoon/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "harpoon"
+version = "0.1.0"
+edition = "2021"
+authors = ["Ignacio Aleman <onsen@duck.com>"]
+
+[dependencies]
+serde = "1.0.175"
+serde_json = "1.0.103"
+zellij-tile = "0.42.2"

--- a/harpoon/src/main.rs
+++ b/harpoon/src/main.rs
@@ -142,8 +142,9 @@ impl State {
         format!("${{XDG_DATA_HOME:-$HOME/.local/share}}/zellij-harpoon/{}-timestamps.json", session_name)
     }
 
-    fn load_worker_timestamps(&self) {
+    fn load_worker_timestamps(&mut self) {
         let Some(session) = &self.session_name else { return };
+        self.timestamps_loaded = false;
         let file_path = Self::timestamps_file_path(session);
         let cmd = format!("cat {} 2>/dev/null || echo '{{\"entries\":[]}}'", file_path);
         let mut ctx = BTreeMap::new();

--- a/harpoon/src/main.rs
+++ b/harpoon/src/main.rs
@@ -11,7 +11,7 @@ use zellij_tile::prelude::*;
 fn now_secs() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
 

--- a/harpoon/src/main.rs
+++ b/harpoon/src/main.rs
@@ -262,7 +262,8 @@ impl State {
                     for pane in manifest_panes {
                         if !pane.is_plugin && !current_ids.contains(&pane.id) {
                             let ts = self.worker_timestamps.entries.iter()
-                                .find(|e| e.pane_id == pane.id || (e.tab_name == tab.name && e.pane_title == pane.title))
+                                .find(|e| e.pane_id == pane.id)
+                                .or_else(|| self.worker_timestamps.entries.iter().find(|e| e.pane_id == 0 && e.tab_name == tab.name && e.pane_title == pane.title))
                                 .map(|e| e.last_accessed)
                                 .unwrap_or(0);
                             if ts > 0 {
@@ -279,7 +280,8 @@ impl State {
             // Update timestamps for existing panes from worker data
             for pane in self.panes.iter_mut() {
                 let ts = self.worker_timestamps.entries.iter()
-                    .find(|e| e.pane_id == pane.pane_info.id || (e.tab_name == pane.tab_info.name && e.pane_title == pane.pane_info.title))
+                    .find(|e| e.pane_id == pane.pane_info.id)
+                    .or_else(|| self.worker_timestamps.entries.iter().find(|e| e.pane_id == 0 && e.tab_name == pane.tab_info.name && e.pane_title == pane.pane_info.title))
                     .map(|e| e.last_accessed)
                     .unwrap_or(0);
                 if ts > pane.last_accessed {

--- a/harpoon/src/main.rs
+++ b/harpoon/src/main.rs
@@ -134,6 +134,8 @@ struct State {
     recent_sort: bool,
     worker_timestamps: TimestampMap,
     timestamps_loaded: bool,
+    search_query: String,
+    search_mode: bool,
 }
 
 impl State {
@@ -154,17 +156,25 @@ impl State {
 
     /// Returns indices into self.panes that should be displayed.
     fn display_indices(&self) -> Vec<usize> {
+        let query = self.search_query.to_lowercase();
         self.panes
             .iter()
             .enumerate()
             .filter(|(_, p)| {
-                if !self.recent_sort {
-                    return true;
+                if self.recent_sort {
+                    if let Some(f) = &self.focused_pane {
+                        if f.pane_info.id == p.pane_info.id {
+                            return false;
+                        }
+                    }
                 }
-                self.focused_pane
-                    .as_ref()
-                    .map(|f| f.pane_info.id != p.pane_info.id)
-                    .unwrap_or(true)
+                if !query.is_empty() {
+                    let haystack = format!("{} | {}", p.tab_info.name, p.pane_info.title).to_lowercase();
+                    if !fuzzy_match(&query, &haystack) {
+                        return false;
+                    }
+                }
+                true
             })
             .map(|(i, _)| i)
             .collect()
@@ -386,85 +396,137 @@ impl ZellijPlugin for State {
                     should_render = true;
                 }
             }
-            Event::Key(key) => match key.bare_key {
-                BareKey::Char('A') => {
-                    // Add all terminal panes from all tabs that aren't already tracked
-                    let current_ids: Vec<u32> = self.panes.iter().map(|p| p.pane_info.id).collect();
-                    if let Some(pane_manifest) = &self.pane_manifest {
-                        if let Some(tab_info) = &self.tab_info {
-                            for (tab_position, panes) in &pane_manifest.panes {
-                                if let Some(tab) = tab_info.iter().find(|t| t.position == *tab_position) {
-                                    for pane in panes {
-                                        if !pane.is_plugin && !current_ids.contains(&pane.id) {
-                                            self.panes.push(Pane {
-                                                pane_info: pane.clone(),
-                                                tab_info: tab.clone(),
-                                                last_accessed: 0,
-                                            });
+            Event::Key(key) => if self.search_mode {
+                match key.bare_key {
+                    BareKey::Esc => {
+                        self.search_mode = false;
+                        self.search_query.clear();
+                        self.selected = 0;
+                        self.clamp_selected();
+                        should_render = true;
+                    }
+                    BareKey::Backspace => {
+                        self.search_query.pop();
+                        if self.search_query.is_empty() {
+                            self.search_mode = false;
+                        }
+                        self.selected = 0;
+                        self.clamp_selected();
+                        should_render = true;
+                    }
+                    BareKey::Enter => {
+                        if let Some(idx) = self.selected_pane_index() {
+                            self.panes[idx].last_accessed = now_secs();
+                            let pane_id = self.panes[idx].pane_info.id;
+                            self.persistence
+                                .save_to_disk(&self.session_name, &self.panes);
+                            self.search_mode = false;
+                            self.search_query.clear();
+                            hide_self();
+                            focus_terminal_pane(pane_id, true);
+                        }
+                    }
+                    BareKey::Down => {
+                        if self.display_len() > 0 {
+                            self.select_down();
+                            should_render = true;
+                        }
+                    }
+                    BareKey::Up => {
+                        if self.display_len() > 0 {
+                            self.select_up();
+                            should_render = true;
+                        }
+                    }
+                    BareKey::Char(c) => {
+                        self.search_query.push(c);
+                        self.selected = 0;
+                        self.clamp_selected();
+                        should_render = true;
+                    }
+                    _ => (),
+                }
+            } else {
+                match key.bare_key {
+                    BareKey::Char('/') => {
+                        self.search_mode = true;
+                        should_render = true;
+                    }
+                    BareKey::Char('A') => {
+                        let current_ids: Vec<u32> = self.panes.iter().map(|p| p.pane_info.id).collect();
+                        if let Some(pane_manifest) = &self.pane_manifest {
+                            if let Some(tab_info) = &self.tab_info {
+                                for (tab_position, panes) in &pane_manifest.panes {
+                                    if let Some(tab) = tab_info.iter().find(|t| t.position == *tab_position) {
+                                        for pane in panes {
+                                            if !pane.is_plugin && !current_ids.contains(&pane.id) {
+                                                self.panes.push(Pane {
+                                                    pane_info: pane.clone(),
+                                                    tab_info: tab.clone(),
+                                                    last_accessed: 0,
+                                                });
+                                            }
                                         }
                                     }
                                 }
                             }
                         }
+                        self.sort_panes();
+                        self.persistence
+                            .save_to_disk(&self.session_name, &self.panes);
+                        should_render = true;
+                        hide_self();
                     }
-                    self.sort_panes();
-                    self.persistence
-                        .save_to_disk(&self.session_name, &self.panes);
-                    should_render = true;
-                    hide_self();
-                }
-                BareKey::Char('a') => {
-                    // Add the currently focused terminal pane if not already tracked.
-                    // Since pane IDs are session-unique for terminal panes, we only
-                    // need to check the ID (not tab position).
-                    if let Some(pane) = &self.focused_pane {
-                        if !self.panes.iter().any(|p| p.pane_info.id == pane.pane_info.id) {
-                            let mut new_pane = pane.clone();
-                            new_pane.last_accessed = now_secs();
-                            self.panes.push(new_pane);
-                            self.sort_panes();
+                    BareKey::Char('a') => {
+                        if let Some(pane) = &self.focused_pane {
+                            if !self.panes.iter().any(|p| p.pane_info.id == pane.pane_info.id) {
+                                let mut new_pane = pane.clone();
+                                new_pane.last_accessed = now_secs();
+                                self.panes.push(new_pane);
+                                self.sort_panes();
+                                self.persistence
+                                    .save_to_disk(&self.session_name, &self.panes);
+                            }
+                        }
+                        should_render = true;
+                        hide_self();
+                    }
+                    BareKey::Char('d') => {
+                        if let Some(idx) = self.selected_pane_index() {
+                            self.panes.remove(idx);
                             self.persistence
                                 .save_to_disk(&self.session_name, &self.panes);
                         }
-                    }
-                    should_render = true;
-                    hide_self();
-                }
-                BareKey::Char('d') => {
-                    if let Some(idx) = self.selected_pane_index() {
-                        self.panes.remove(idx);
-                        self.persistence
-                            .save_to_disk(&self.session_name, &self.panes);
-                    }
-                    self.clamp_selected();
-                    should_render = true;
-                }
-                BareKey::Char('c') | BareKey::Esc => {
-                    hide_self();
-                }
-                BareKey::Down | BareKey::Char('j') => {
-                    if self.display_len() > 0 {
-                        self.select_down();
+                        self.clamp_selected();
                         should_render = true;
                     }
-                }
-                BareKey::Up | BareKey::Char('k') => {
-                    if self.display_len() > 0 {
-                        self.select_up();
-                        should_render = true;
-                    }
-                }
-                BareKey::Enter | BareKey::Char('l') => {
-                    if let Some(idx) = self.selected_pane_index() {
-                        self.panes[idx].last_accessed = now_secs();
-                        let pane_id = self.panes[idx].pane_info.id;
-                        self.persistence
-                            .save_to_disk(&self.session_name, &self.panes);
+                    BareKey::Char('c') | BareKey::Esc => {
                         hide_self();
-                        focus_terminal_pane(pane_id, true);
                     }
+                    BareKey::Down | BareKey::Char('j') => {
+                        if self.display_len() > 0 {
+                            self.select_down();
+                            should_render = true;
+                        }
+                    }
+                    BareKey::Up | BareKey::Char('k') => {
+                        if self.display_len() > 0 {
+                            self.select_up();
+                            should_render = true;
+                        }
+                    }
+                    BareKey::Enter | BareKey::Char('l') => {
+                        if let Some(idx) = self.selected_pane_index() {
+                            self.panes[idx].last_accessed = now_secs();
+                            let pane_id = self.panes[idx].pane_info.id;
+                            self.persistence
+                                .save_to_disk(&self.session_name, &self.panes);
+                            hide_self();
+                            focus_terminal_pane(pane_id, true);
+                        }
+                    }
+                    _ => (),
                 }
-                _ => (),
             },
             _ => (),
         };
@@ -473,22 +535,32 @@ impl ZellijPlugin for State {
     }
 
     fn render(&mut self, rows: usize, cols: usize) {
-        // Note: y=0 overlaps with the zellij pane frame/title bar and is not visible,
-        // so we start rendering from y=1.
         let display = self.display_indices();
+        let mut y = 0;
 
-        let header = format!("==== {} panes ====", display.len());
-        let x = cols.saturating_sub(header.len()) / 2;
-        print_text_with_coordinates(Text::new(&header), x, 0, None, None);
-        let mut y = 1;
+        if self.search_mode {
+            let search_line = format!("/{}", self.search_query);
+            print_text_with_coordinates(Text::new(&search_line), 0, y, None, None);
+        } else {
+            let header = format!("==== {} panes ====", display.len());
+            let x = cols.saturating_sub(header.len()) / 2;
+            print_text_with_coordinates(Text::new(&header), x, y, None, None);
+        }
+        y += 1;
 
         for (display_idx, &pane_idx) in display.iter().enumerate() {
             let pane = &self.panes[pane_idx];
-            let text = if display_idx == self.selected {
-                Text::new(&pane.to_string()).selected()
+            let pane_str = pane.to_string();
+            let mut text = if display_idx == self.selected {
+                Text::new(&pane_str).selected()
             } else {
-                Text::new(&pane.to_string())
+                Text::new(&pane_str)
             };
+            if self.search_mode && !self.search_query.is_empty() {
+                for range in fuzzy_match_indices(&self.search_query, &pane_str) {
+                    text = text.color_range(3, range);
+                }
+            }
             print_text_with_coordinates(text, 0, y, None, None);
             y += 1;
         }
@@ -497,6 +569,34 @@ impl ZellijPlugin for State {
         let hint_line = build_hint_line(cols);
         print_text_with_coordinates(hint_line, 0, hint_y, None, None);
     }
+}
+
+/// Fuzzy match: all characters in needle must appear in haystack in order.
+fn fuzzy_match(needle: &str, haystack: &str) -> bool {
+    let mut haystack_chars = haystack.chars();
+    for nc in needle.chars() {
+        if haystack_chars.find(|&hc| hc == nc).is_none() {
+            return false;
+        }
+    }
+    true
+}
+
+/// Returns byte-offset ranges of matched characters for highlighting.
+fn fuzzy_match_indices(needle: &str, haystack: &str) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = Vec::new();
+    let needle_lower = needle.to_lowercase();
+    let haystack_lower = haystack.to_lowercase();
+    let mut h_iter = haystack_lower.char_indices().peekable();
+    for nc in needle_lower.chars() {
+        while let Some((byte_pos, hc)) = h_iter.next() {
+            if hc == nc {
+                ranges.push(byte_pos..byte_pos + hc.len_utf8());
+                break;
+            }
+        }
+    }
+    ranges
 }
 
 fn build_hint_line(cols: usize) -> Text {

--- a/harpoon/src/main.rs
+++ b/harpoon/src/main.rs
@@ -4,8 +4,16 @@ use core::fmt;
 use persistence::Persistence;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use zellij_tile::prelude::*;
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 /// A tracked pane, combining zellij's PaneInfo with its parent TabInfo.
 ///
@@ -19,6 +27,8 @@ use zellij_tile::prelude::*;
 pub struct Pane {
     pub pane_info: PaneInfo,
     pub tab_info: TabInfo,
+    #[serde(default)]
+    pub last_accessed: u64,
 }
 
 impl fmt::Display for Pane {
@@ -88,6 +98,7 @@ fn get_valid_panes(
                     new_panes.push(Pane {
                         pane_info: pane_info.clone(),
                         tab_info: tab_info.clone(),
+                        last_accessed: pane.last_accessed,
                     });
                     break;
                 }
@@ -95,6 +106,20 @@ fn get_valid_panes(
         }
     }
     new_panes
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct TimestampMap {
+    entries: Vec<TimestampEntry>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct TimestampEntry {
+    tab_name: String,
+    pane_title: String,
+    #[serde(default)]
+    pane_id: u32,
+    last_accessed: u64,
 }
 
 #[derive(Default)]
@@ -106,37 +131,88 @@ struct State {
     pane_manifest: Option<PaneManifest>,
     session_name: Option<String>,
     persistence: Persistence,
+    recent_sort: bool,
+    worker_timestamps: TimestampMap,
+    timestamps_loaded: bool,
 }
 
 impl State {
+
+    fn timestamps_file_path(session_name: &str) -> String {
+        format!("${{XDG_DATA_HOME:-$HOME/.local/share}}/zellij-harpoon/{}-timestamps.json", session_name)
+    }
+
+    fn load_worker_timestamps(&self) {
+        let Some(session) = &self.session_name else { return };
+        let file_path = Self::timestamps_file_path(session);
+        let cmd = format!("cat {} 2>/dev/null || echo '{{\"entries\":[]}}'", file_path);
+        let mut ctx = BTreeMap::new();
+        ctx.insert("source".to_string(), "timestamps".to_string());
+        run_command(&["sh", "-c", &cmd], ctx);
+    }
+
+    /// Returns indices into self.panes that should be displayed.
+    fn display_indices(&self) -> Vec<usize> {
+        self.panes
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| {
+                if !self.recent_sort {
+                    return true;
+                }
+                self.focused_pane
+                    .as_ref()
+                    .map(|f| f.pane_info.id != p.pane_info.id)
+                    .unwrap_or(true)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    fn display_len(&self) -> usize {
+        self.display_indices().len()
+    }
+
     fn clamp_selected(&mut self) {
-        if self.panes.is_empty() {
+        let len = self.display_len();
+        if len == 0 {
             self.selected = 0;
-        } else if self.selected >= self.panes.len() {
-            self.selected = self.panes.len() - 1;
+        } else if self.selected >= len {
+            self.selected = len - 1;
         }
     }
 
     fn select_down(&mut self) {
-        if self.panes.is_empty() {
+        let len = self.display_len();
+        if len == 0 {
             return;
         }
-        self.selected = (self.selected + 1) % self.panes.len();
+        self.selected = (self.selected + 1) % len;
     }
 
     fn select_up(&mut self) {
-        if self.panes.is_empty() {
+        let len = self.display_len();
+        if len == 0 {
             return;
         }
         if self.selected == 0 {
-            self.selected = self.panes.len() - 1;
+            self.selected = len - 1;
             return;
         }
         self.selected -= 1;
     }
 
+    /// Maps the display-list selected index to the actual index in self.panes.
+    fn selected_pane_index(&self) -> Option<usize> {
+        self.display_indices().get(self.selected).copied()
+    }
+
     fn sort_panes(&mut self) {
-        self.panes.sort_by(|x, y| x.tab_info.position.cmp(&y.tab_info.position));
+        if self.recent_sort {
+            self.panes.sort_by(|x, y| y.last_accessed.cmp(&x.last_accessed));
+        } else {
+            self.panes.sort_by(|x, y| x.tab_info.position.cmp(&y.tab_info.position));
+        }
     }
 
     /// Reconciles the stored pane list against the latest manifest and updates
@@ -162,13 +238,58 @@ impl State {
         let focused_pane_info = get_focused_pane(focused_tab.position, &pane_manifest)?;
         self.focused_pane = Some(Pane {
             pane_info: focused_pane_info,
-            tab_info: focused_tab,
+            tab_info: focused_tab.clone(),
+            last_accessed: 0,
         });
 
-        // Move cursor to the focused pane if it's in the list
-        if let Some(focused) = &self.focused_pane {
-            if let Some(idx) = self.panes.iter().position(|p| p.pane_info.id == focused.pane_info.id) {
-                self.selected = idx;
+        // In recent_sort mode, merge worker timestamps into panes and auto-add all panes
+        if self.recent_sort && self.timestamps_loaded {
+            // Auto-add all terminal panes from manifest
+            let current_ids: Vec<u32> = self.panes.iter().map(|p| p.pane_info.id).collect();
+            for (tab_position, manifest_panes) in &pane_manifest.panes {
+                if let Some(tab) = tab_info.iter().find(|t| t.position == *tab_position) {
+                    for pane in manifest_panes {
+                        if !pane.is_plugin && !current_ids.contains(&pane.id) {
+                            let ts = self.worker_timestamps.entries.iter()
+                                .find(|e| e.pane_id == pane.id || (e.tab_name == tab.name && e.pane_title == pane.title))
+                                .map(|e| e.last_accessed)
+                                .unwrap_or(0);
+                            if ts > 0 {
+                                self.panes.push(Pane {
+                                    pane_info: pane.clone(),
+                                    tab_info: tab.clone(),
+                                    last_accessed: ts,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            // Update timestamps for existing panes from worker data
+            for pane in self.panes.iter_mut() {
+                let ts = self.worker_timestamps.entries.iter()
+                    .find(|e| e.pane_id == pane.pane_info.id || (e.tab_name == pane.tab_info.name && e.pane_title == pane.pane_info.title))
+                    .map(|e| e.last_accessed)
+                    .unwrap_or(0);
+                if ts > pane.last_accessed {
+                    pane.last_accessed = ts;
+                }
+            }
+            self.sort_panes();
+        }
+
+        // In recent_sort mode, always start at 0 (most recent, excluding focused).
+        // Otherwise, move cursor to the focused pane if it's in the list.
+        if self.recent_sort {
+            self.selected = 0;
+        } else {
+            if let Some(focused) = &self.focused_pane {
+                let display = self.display_indices();
+                if let Some(display_idx) = display.iter().position(|&i| {
+                    self.panes[i].pane_info.id == focused.pane_info.id
+                }) {
+                    self.selected = display_idx;
+                }
             }
         }
         self.clamp_selected();
@@ -185,7 +306,11 @@ impl State {
 register_plugin!(State);
 
 impl ZellijPlugin for State {
-    fn load(&mut self, _: BTreeMap<String, String>) {
+    fn load(&mut self, configuration: BTreeMap<String, String>) {
+        self.recent_sort = configuration
+            .get("recent_sort")
+            .map(|v| v == "true")
+            .unwrap_or(false);
         request_permission(&[
             PermissionType::RunCommands,
             PermissionType::ReadApplicationState,
@@ -206,11 +331,17 @@ impl ZellijPlugin for State {
         match event {
             Event::TabUpdate(tab_info) => {
                 self.tab_info = Some(tab_info);
+                if self.recent_sort && self.session_name.is_some() {
+                    self.load_worker_timestamps();
+                }
                 self.update_panes();
                 should_render = true;
             }
             Event::PaneUpdate(pane_manifest) => {
                 self.pane_manifest = Some(pane_manifest);
+                if self.recent_sort && self.session_name.is_some() {
+                    self.load_worker_timestamps();
+                }
                 self.update_panes();
                 should_render = true;
             }
@@ -225,11 +356,15 @@ impl ZellijPlugin for State {
                     if let Some(current) = session_infos.iter().find(|s| s.is_current_session) {
                         self.session_name = Some(current.name.clone());
                         self.persistence.load_from_disk(&self.session_name);
+                        if self.recent_sort {
+                            self.load_worker_timestamps();
+                        }
                     }
                 }
             }
             Event::RunCommandResult(_exit_code, stdout, _stderr, context) => {
-                if context.get("source").map(|s| s.as_str()) == Some("load") {
+                let source = context.get("source").map(|s| s.as_str());
+                if source == Some("load") {
                     let content = String::from_utf8_lossy(&stdout);
                     match self.persistence.on_load_command(&content) {
                         Ok(_) => {
@@ -240,6 +375,14 @@ impl ZellijPlugin for State {
                             eprintln!("{e}");
                         }
                     }
+                } else if source == Some("timestamps") {
+                    let content = String::from_utf8_lossy(&stdout);
+                    if let Ok(map) = serde_json::from_str::<TimestampMap>(&content) {
+                        self.worker_timestamps = map;
+                    }
+                    self.timestamps_loaded = true;
+                    self.update_panes();
+                    should_render = true;
                 }
             }
             Event::Key(key) => match key.bare_key {
@@ -255,6 +398,7 @@ impl ZellijPlugin for State {
                                             self.panes.push(Pane {
                                                 pane_info: pane.clone(),
                                                 tab_info: tab.clone(),
+                                                last_accessed: 0,
                                             });
                                         }
                                     }
@@ -274,7 +418,9 @@ impl ZellijPlugin for State {
                     // need to check the ID (not tab position).
                     if let Some(pane) = &self.focused_pane {
                         if !self.panes.iter().any(|p| p.pane_info.id == pane.pane_info.id) {
-                            self.panes.push(pane.clone());
+                            let mut new_pane = pane.clone();
+                            new_pane.last_accessed = now_secs();
+                            self.panes.push(new_pane);
                             self.sort_panes();
                             self.persistence
                                 .save_to_disk(&self.session_name, &self.panes);
@@ -284,8 +430,8 @@ impl ZellijPlugin for State {
                     hide_self();
                 }
                 BareKey::Char('d') => {
-                    if self.selected < self.panes.len() {
-                        self.panes.remove(self.selected);
+                    if let Some(idx) = self.selected_pane_index() {
+                        self.panes.remove(idx);
                         self.persistence
                             .save_to_disk(&self.session_name, &self.panes);
                     }
@@ -296,22 +442,25 @@ impl ZellijPlugin for State {
                     hide_self();
                 }
                 BareKey::Down | BareKey::Char('j') => {
-                    if self.panes.len() > 0 {
+                    if self.display_len() > 0 {
                         self.select_down();
                         should_render = true;
                     }
                 }
                 BareKey::Up | BareKey::Char('k') => {
-                    if self.panes.len() > 0 {
+                    if self.display_len() > 0 {
                         self.select_up();
                         should_render = true;
                     }
                 }
                 BareKey::Enter | BareKey::Char('l') => {
-                    if let Some(pane) = self.panes.get(self.selected) {
+                    if let Some(idx) = self.selected_pane_index() {
+                        self.panes[idx].last_accessed = now_secs();
+                        let pane_id = self.panes[idx].pane_info.id;
+                        self.persistence
+                            .save_to_disk(&self.session_name, &self.panes);
                         hide_self();
-                        // TODO: This has a bug on macOS with hidden panes
-                        focus_terminal_pane(pane.pane_info.id, true);
+                        focus_terminal_pane(pane_id, true);
                     }
                 }
                 _ => (),
@@ -325,13 +474,16 @@ impl ZellijPlugin for State {
     fn render(&mut self, rows: usize, cols: usize) {
         // Note: y=0 overlaps with the zellij pane frame/title bar and is not visible,
         // so we start rendering from y=1.
-        let header = format!("==== {} panes ====", self.panes.len());
+        let display = self.display_indices();
+
+        let header = format!("==== {} panes ====", display.len());
         let x = cols.saturating_sub(header.len()) / 2;
         print_text_with_coordinates(Text::new(&header), x, 0, None, None);
         let mut y = 1;
 
-        for (idx, pane) in self.panes.iter().enumerate() {
-            let text = if idx == self.selected {
+        for (display_idx, &pane_idx) in display.iter().enumerate() {
+            let pane = &self.panes[pane_idx];
+            let text = if display_idx == self.selected {
                 Text::new(&pane.to_string()).selected()
             } else {
                 Text::new(&pane.to_string())

--- a/harpoon/src/persistence.rs
+++ b/harpoon/src/persistence.rs
@@ -9,12 +9,14 @@ use crate::Pane;
 struct PaneBookmark {
     tab_name: String,
     pane_title: String,
+    #[serde(default)]
+    last_accessed: u64,
 }
 
 #[derive(Default)]
 pub struct Persistence {
     pending_bookmarks: Vec<PaneBookmark>,
-    last_saved_state: Vec<(String, String)>,
+    last_saved_state: Vec<(String, String, u64)>,
 }
 
 #[derive(Debug)]
@@ -48,7 +50,8 @@ impl Persistence {
 
         self.pending_bookmarks.retain(|bookmark| {
             match find_pane_for_bookmark(bookmark, pane_manifest, tab_infos, &current_pane_ids) {
-                Some(pane) => {
+                Some(mut pane) => {
+                    pane.last_accessed = bookmark.last_accessed;
                     current_pane_ids.push(pane.pane_info.id);
                     new_panes.push(pane);
                     false
@@ -61,9 +64,9 @@ impl Persistence {
     }
 
     pub fn has_changed(&self, panes: &[Pane]) -> bool {
-        let current: Vec<(String, String)> = panes
+        let current: Vec<(String, String, u64)> = panes
             .iter()
-            .map(|p| (p.tab_info.name.clone(), p.pane_info.title.clone()))
+            .map(|p| (p.tab_info.name.clone(), p.pane_info.title.clone(), p.last_accessed))
             .collect();
         current != self.last_saved_state
     }
@@ -90,12 +93,11 @@ impl Persistence {
     pub fn on_load_command(&mut self, content: &str) -> Result<(), PersistenceError> {
         match serde_json::from_str::<Vec<PaneBookmark>>(content) {
             Ok(bookmarks) => {
-                self.pending_bookmarks = bookmarks;
-                self.last_saved_state = self
-                    .pending_bookmarks
+                self.last_saved_state = bookmarks
                     .iter()
-                    .map(|b| (b.tab_name.clone(), b.pane_title.clone()))
+                    .map(|b| (b.tab_name.clone(), b.pane_title.clone(), b.last_accessed))
                     .collect();
+                self.pending_bookmarks = bookmarks;
                 Ok(())
             }
             Err(e) => Err(PersistenceError::LoadFromDiskFailed(e)),
@@ -111,6 +113,7 @@ impl Persistence {
             .map(|p| PaneBookmark {
                 tab_name: p.tab_info.name.clone(),
                 pane_title: p.pane_info.title.clone(),
+                last_accessed: p.last_accessed,
             })
             .collect();
 
@@ -126,7 +129,7 @@ impl Persistence {
 
         self.last_saved_state = bookmarks
             .iter()
-            .map(|b| (b.tab_name.clone(), b.pane_title.clone()))
+            .map(|b| (b.tab_name.clone(), b.pane_title.clone(), b.last_accessed))
             .collect();
     }
 }
@@ -153,6 +156,7 @@ fn find_pane_for_bookmark(
             .map(|pane| Pane {
                 pane_info: pane.clone(),
                 tab_info: tab.clone(),
+                last_accessed: 0,
             });
 
         if matched_pane.is_some() {


### PR DESCRIPTION
## Summary

Add a `recent_sort` option that sorts the pane list by last accessed time, similar to JetBrains' Recent Files (`Ctrl+E`). When enabled, the current focused pane is hidden from the list, so the first item is always your previous pane — enabling quick back-and-forth switching with no manual list management.

## Motivation

The default harpoon behavior sorts panes by tab position, which doesn't reflect actual usage patterns. Users frequently switch between a small set of panes and want instant access to their most recently used ones without having to manually reorder or curate the list.

## Implementation

Since zellij suspends hidden/floating plugins (they stop receiving events), a background worker plugin is needed to continuously track pane focus changes.

**Architecture:**
- **harpoon-worker**: a background plugin that monitors `PaneUpdate`/`TabUpdate` events, detects focus changes, and persists timestamps to `~/.local/share/zellij-harpoon/{session}-timestamps.json`
- **harpoon**: reads the worker's timestamp file on open, auto-adds any pane that has been focused, and sorts by recency

**Project structure** is converted to a Cargo workspace with two crates (`harpoon/` and `harpoon-worker/`).

## Configuration

```kdl
shared_except "locked" {
    bind "Ctrl y" {
        LaunchOrFocusPlugin "file:~/.config/zellij/plugins/harpoon.wasm" {
            floating true; move_to_focused_tab true;
            recent_sort "true"
        }
    }
}
```

The worker must be loaded separately:

```kdl
load_plugins {
    "file:~/.config/zellij/plugins/harpoon-worker.wasm"
}
```

An optional `debug "true"` config on the worker enables logging to `~/.local/share/zellij-harpoon/{session}-debug.log`.

## What was tested

- Pane focus tracking across tabs via Alt+h/j/k/l and mouse
- Rapid pane switching (millisecond-precision timestamps)
- Opening harpoon from different panes verifies correct sort order
- New tabs/panes are automatically tracked on first focus
- Backward compatibility: without `recent_sort`, behavior is unchanged

